### PR TITLE
Add/train keras highres3dnet

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,38 +1,22 @@
-# Dockerfile for the brain extraction neural network project.
+# Dockerfile for 3D semantic segmentation project.
 #
 # - Use `singularity pull ...` to convert the resulting docker image to a
 #   singularity image.
 # - Use singularity >= 2.3.0 to mount local NVIDIA drivers with the --nv option.
 
-FROM tensorflow/tensorflow:1.2.0-gpu-py3
+FROM tensorflow/tensorflow:1.4.0-gpu-py3
 
 LABEL maintainer="Jakub Kaczmarzyk <jakubk@mit.edu>"
-
-# This is not set automatically for some reason. Causes `import tensorflow` to break.
-ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/cuda/lib64"
 
 RUN pip install --no-cache-dir -U pip \
     && pip install --no-cache-dir h5py \
                                   keras \
                                   nibabel \
-                                  opencv-python
+                                  numpy \
+                                  scikit-image
 
-# Install NiftyNet
-RUN pip install --no-cache-dir packaging \
-    && pip install --no-cache-dir niftynet
 
-# Install DLTK
-RUN mkdir /opt/dltk \
-    && curl -sSL https://github.com/DLTK/DLTK/tarball/master \
-    | tar xz -C /opt/dltk --strip-components=1 \
-    && pip install -e /opt/dltk \
-    && chmod 777 -R /opt/dltk
-
-RUN curl -sSL https://github.com/ellisdg/3DUnetCNN/tarball/master \
-    | tar xz -C /opt \
-    && curl -sSL https://github.com/ncullen93/Unet-ants/tarball/master \
-    | tar xz -C /opt \
-    && chmod 777 -R /opt
-
-WORKDIR /home
+RUN useradd --no-user-group --create-home --shell /bin/bash neuro
+USER neuro
+WORKDIR /home/neuro
 ENTRYPOINT ["/usr/bin/python"]

--- a/niftynet_to_keras/highres3dnet.ipynb
+++ b/niftynet_to_keras/highres3dnet.ipynb
@@ -1,0 +1,164 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Implement highres3dnet\n",
+    "\n",
+    "Paper: https://arxiv.org/abs/1707.01992\n",
+    "\n",
+    "Future considerations\n",
+    "---\n",
+    "- Modify `highres3dnet` to use ResNeXt architechture. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "\n",
+    "import nibabel as nib\n",
+    "import numpy as np\n",
+    "\n",
+    "from highres3dnet import dice_coef, dice_loss, HighRes3DNet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "volume_input_shape = (256, 256, 256, 1)\n",
+    "model = HighRes3DNet(2, input_shape=volume_input_shape)\n",
+    "model.input_shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "img = nib.load('../data/brainmask.nii.gz')\n",
+    "img_data = img.get_fdata()\n",
+    "\n",
+    "if img_data.ndim < 3:\n",
+    "    raise ValueError(\"Invalid number of dimensions. Input volume must have\"\n",
+    "                     \" at least 3 dimensions.\")\n",
+    "\n",
+    "img_data = np.squeeze(img_data)\n",
+    "if img_data.ndim != 3:\n",
+    "    raise ValueError(\"Invalid number of non-single-dimensional entries.\"\n",
+    "                     \" Data must have 3 dimensions after squeezing\"\n",
+    "                     \" single-dimensional entries.\")\n",
+    "\n",
+    "logging.info(\"Resizing image to shape {} from shape {}\"\n",
+    "             .format(img_data.shape, volume_input_shape))\n",
+    "img_data = img_data.reshape(volume_input_shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "batch_data = np.stack((img_data, img_data, img_data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "model.compile('adam', dice_loss)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "model.train_on_batch(batch_data, mask_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:tf-cpu]",
+   "language": "python",
+   "name": "conda-env-tf-cpu-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  },
+  "toc": {
+   "colors": {
+    "hover_highlight": "#DAA520",
+    "running_highlight": "#FF0000",
+    "selected_highlight": "#FFD700"
+   },
+   "moveMenuLeft": true,
+   "nav_menu": {
+    "height": "30px",
+    "width": "252px"
+   },
+   "navigate_menu": true,
+   "number_sections": false,
+   "sideBar": true,
+   "threshold": 4,
+   "toc_cell": false,
+   "toc_section_display": "block",
+   "toc_window_display": false,
+   "widenNotebook": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/niftynet_to_keras/highres3dnet.ipynb
+++ b/niftynet_to_keras/highres3dnet.ipynb
@@ -8,9 +8,38 @@
     "\n",
     "Paper: https://arxiv.org/abs/1707.01992\n",
     "\n",
+    "Preprocessing steps\n",
+    "---\n",
+    "- Anatomical\n",
+    "    1. Load.\n",
+    "    1. Squeeze data array.\n",
+    "    1. Check for 3 dimensions.\n",
+    "    1. Add one color channel.\n",
+    "- Labels\n",
+    "    1. Load.\n",
+    "    1. Squeeze data array.\n",
+    "    1. Check for 3 dimensions.\n",
+    "    1. One-hot encode.\n",
+    "   \n",
+    "Loading steps\n",
+    "---\n",
+    "1. Load anatomical and labels.\n",
+    "1. Get blocks for each array.\n",
+    "1. Feed those blocks into the model in batches.\n",
+    "\n",
+    "Questions\n",
+    "---\n",
+    "1. Should we impose a restriction, where batch size must be evenly divisible by number of blocks (viewpoints) that are in a volume? Probably.\n",
+    "\n",
+    "Todo\n",
+    "---\n",
+    "- Look into [`keras.utils.multi_gpu_model`](https://keras.io/utils/#multi_gpu_model) to train on multiple GPUs. This is only available for the TensorFlow backend.\n",
+    "- Learn about one-hot encoding / decoding. Encode the array of labels with `K.one_hot()`. Decode the predictions with `K.argmax()`. `K.one_hot()` simply calls `tf.one_hot()`, so this would restrict us to the TensorFlow backend, which is fine for now.\n",
+    "\n",
+    "\n",
     "Notes\n",
     "---\n",
-    "- NiftyNet trains on a sliding window over the 3D data.\n",
+    "- NiftyNet trains on a sliding window over the 3D data. This should have that ability to lower GPU memory requirements.\n",
     "\n",
     "Future considerations\n",
     "---\n",
@@ -20,7 +49,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "import logging\n",
@@ -29,8 +60,14 @@
     "import nibabel as nib\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "import skimage\n",
+    "from sklearn.feature_extraction.image import extract_patches\n",
+    "import tensorflow as tf\n",
+    "from tensorflow.python.keras import backend as K\n",
     "\n",
-    "from highres3dnet import dice_coef, dice_loss, HighRes3DNet"
+    "from highres3dnet import dice_coef, dice_loss, HighRes3DNet\n",
+    "\n",
+    "logger = logging.getLogger(name=__name__)"
    ]
   },
   {
@@ -39,7 +76,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "logger = logging.getLogger(name=__name__)"
+    "config = {\n",
+    "    'batch_size': 16,\n",
+    "    'block_shape': (64, 64, 64, 1),  # size of input to model.\n",
+    "    'image_data_format': 'channels_last',\n",
+    "    'n_classes': 2,\n",
+    "    'volume_shape': (256, 256, 256, 1),\n",
+    "}\n",
+    "\n",
+    "K.set_image_data_format(config['image_data_format'])"
    ]
   },
   {
@@ -52,7 +97,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "input_filepath = \"/om/user/jakubk/nobrainer-code/niftynet_to_keras/t1_brainmask.csv\"\n",
@@ -66,46 +113,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def load_image(filepath):\n",
-    "    \"\"\"Return data and affine given filepath to volume.\"\"\"\n",
-    "    img = nib.load(filepath)\n",
-    "    img.uncache()\n",
-    "    return img.get_fdata(), img.affine\n",
+    "model = HighRes3DNet(n_classes=config['n_classes'], input_shape=config['block_size'])\n",
     "\n",
+    "# Use multiple GPUs.\n",
+    "# gpu_ids = [int(ss) for ss in os.environ['CUDA_VISIBLE_DEVICES'].split(',')]\n",
+    "# model = keras.utils.multi_gpu_model(model, gpus=gpu_ids)\n",
     "\n",
-    "def _validate_dims(data):\n",
-    "    \"\"\"Raise `ValueError` if array of data has fewer than 3 dimensions.\"\"\"\n",
-    "    if data.ndim < 3:\n",
-    "        raise ValueError(\"Invalid number of dimensions. Input volume must have\"\n",
-    "                         \" at least 3 dimensions.\")\n",
-    "\n",
-    "\n",
-    "def _reshape(data, newshape):\n",
-    "    \"\"\"Return new array of shape `newshape`.\"\"\"\n",
-    "    logger.info(\"Resizing image to shape {} from shape {}\"\n",
-    "                 .format(data.shape, newshape))\n",
-    "    return data.reshape(newshape)"
+    "model.input_shape\n",
+    "model.summary()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "volume_input_shape = (256, 256, 256, 1)\n",
-    "model = HighRes3DNet(2, input_shape=volume_input_shape)\n",
-    "model.input_shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -114,31 +130,28 @@
    "outputs": [],
    "source": [
     "row = 0\n",
-    "data_input, data_input_affine = load_image(df_input.loc[row, 't1'])\n",
-    "_validate_dims(data_input)\n",
-    "data_input = _reshape(data_input, volume_input_shape)\n",
+    "offset = 65\n",
+    "data_input = load_volume(df_input.loc[row, 't1'])\n",
+    "# data_input = data_input[offset:volume_input_shape[0]+offset, \n",
+    "#                         offset:volume_input_shape[1]+offset, \n",
+    "#                         offset:volume_input_shape[2]+offset]\n",
     "\n",
-    "data_test, data_test_affine = load_image(df_input.loc[row, 'brainmask'])\n",
+    "_validate_dims(data_input)\n",
+    "# data_input = _reshape(data_input, volume_input_shape)\n",
+    "# data_input = np.expand_dims(data_input, 0)\n",
+    "\n",
+    "data_test = load_volume(df_input.loc[row, 'brainmask'])\n",
+    "# data_test = data_test[offset:volume_input_shape[0]+offset, \n",
+    "#                       offset:volume_input_shape[1]+offset, \n",
+    "#                       offset:volume_input_shape[2]+offset]\n",
     "_validate_dims(data_test)\n",
-    "data_test = _reshape(data_test, volume_input_shape)"
+    "\n",
+    "data_test = K.one_hot(data_test, num_classes=2)\n",
+    "\n",
+    "labels = K.stack((data_test,))\n",
+    "\n",
+    "labels = K.stack((data_test,))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "data_input = np.expand_dims(data_input, 0)\n",
-    "data_test = np.expand_dims(data_test, 0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",
@@ -152,54 +165,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
-    "model.fit(data_input, data_test, batch_size=1, verbose=1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "batch_data = np.stack((img_data, img_data, img_data))"
+    "# model.fit(data_input, data_test, batch_size=1, verbose=1)\n",
+    "model.fit(data_input, labels_np, batch_size=1, verbose=1)"
    ]
   },
   {
@@ -222,8 +194,138 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model.train_on_batch(batch_data, mask_data)"
+    "import math\n",
+    "\n",
+    "\n",
+    "def load_volume(filepath, return_affine=False, c_contiguous=True):\n",
+    "    \"\"\"Return data given filepath to volume. Optionally return affine array.\n",
+    "    \n",
+    "    Making the data array contiguous takes more time during loading, but this\n",
+    "    ultimately saves time when viewing blocks of data with `skimage`.\n",
+    "    \"\"\"\n",
+    "    img = nib.load(filepath)\n",
+    "    data = np.asarray(img.dataobj)\n",
+    "    if c_contiguous:\n",
+    "        data = np.ascontiguousarray(data)\n",
+    "    if return_affine:\n",
+    "        return data, img.affine\n",
+    "    return data\n",
+    "\n",
+    "\n",
+    "def _validate_dims(a, ndim=3):\n",
+    "    \"\"\"Raise `ValueError` if Numpy array `a` has fewer than `ndims` dimensions.\"\"\"\n",
+    "    if a.ndim != ndim:\n",
+    "        msg = \"Expected {} dimensions but got {}.\".format(ndim, a.ndim)\n",
+    "        raise ValueError(msg.format(a.ndim))\n",
+    "\n",
+    "\n",
+    "def get_blocks(a, block_shape):\n",
+    "    \"\"\"\n",
+    "    Examples\n",
+    "    --------\n",
+    "    >>> arr = np.ones((4*4)).reshape(4, 4)\n",
+    "    >>> blocks = get_blocks(arr, (2, 2))\n",
+    "    >>> blocks.shape\n",
+    "    (4, 2, 2)\n",
+    "    >>> np.lib.stride_tricks.as_strided(blocks, shape=arr.shape, strides=arr.strides)\n",
+    "    \"\"\"\n",
+    "    return skimage.util.view_as_blocks(a, block_shape).reshape(-1, *block_shape)\n",
+    "\n",
+    "\n",
+    "def get_num_blocks(volume_shape, block_shape):\n",
+    "    \"\"\"Return number of non-overlapping blocks of `block_shape` in `volume_shape`.\"\"\"\n",
+    "    if len(volume_shape) != len(block_shape):\n",
+    "        raise ValueError(\"Volume and batch must have same number of dimensions.\")\n",
+    "    return np.divide(volume_shape, block_shape).prod()\n",
+    "\n",
+    "\n",
+    "class VolumeSequence(tf.keras.utils.Sequence):\n",
+    "    \"\"\"\"\"\"\n",
+    "    def __init__(self, x_files, y_files, batch_size, volume_shape, \n",
+    "                 block_shape=None):\n",
+    "        self.x, self.y = x_files, y_files\n",
+    "        self.batch_size = batch_size\n",
+    "        self.volume_shape = volume_shape\n",
+    "        self.block_shape = block_shape\n",
+    "\n",
+    "    def __len__(self):\n",
+    "        # return math.ceil(len(self.x) / self.batch_size / self._volumes_per_batch)\n",
+    "        return math.ceil(len(self.x) * self._blocks_per_volume / self.batch_size)\n",
+    "\n",
+    "    def __getitem__(self, idx):\n",
+    "        \"\"\"Assumes that each input volume is the same shape.\"\"\"\n",
+    "        batch_x = self.x[idx * self.batch_size:(idx + 1) * self.batch_size]\n",
+    "        batch_y = self.y[idx * self.batch_size:(idx + 1) * self.batch_size]\n",
+    "        \n",
+    "        \n",
+    "\n",
+    "        return (\n",
+    "\n",
+    "#             np.array([resize(imread(file_name), (200, 200)) for file_name in batch_x]), \n",
+    "#             np.array(batch_y)\n",
+    "        )\n",
+    "    \n",
+    "    @property\n",
+    "    def _blocks_per_volume(self):\n",
+    "        \"\"\"Number of non-overlapping blocks per volume.\"\"\"\n",
+    "        return get_num_blocks(volume_shape=self.volume_shape, \n",
+    "                              block_shape=self.block_shape)\n",
+    "\n",
+    "    @property\n",
+    "    def _volumes_per_batch(self):\n",
+    "        return self.batch_size / self._blocks_per_volume\n",
+    "        # return get_volumes_per_batch(num_blocks=self._blocks_per_volume, \n",
+    "        #                              batch_size=self.batch_size)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aa = VolumeSequence(x_files=df_input['t1'], \n",
+    "                    y_files=df_input['brainmask'], \n",
+    "                    batch_size=config['batch_size'], \n",
+    "                    volume_shape=config['volume_shape'], \n",
+    "                    block_shape=config['block_shape'],\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# __getitem__ should find the correct volume(s) and return the arrays from that.\n",
+    "# batch 0 ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aa._blocks_per_volume"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aa._volumes_per_batch"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/niftynet_to_keras/highres3dnet.ipynb
+++ b/niftynet_to_keras/highres3dnet.ipynb
@@ -8,23 +8,27 @@
     "\n",
     "Paper: https://arxiv.org/abs/1707.01992\n",
     "\n",
+    "Notes\n",
+    "---\n",
+    "- NiftyNet trains on a sliding window over the 3D data.\n",
+    "\n",
     "Future considerations\n",
     "---\n",
-    "- Modify `highres3dnet` to use ResNeXt architechture. "
+    "- Modify `highres3dnet` to use ResNeXt architechture."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import logging\n",
+    "import os\n",
     "\n",
     "import nibabel as nib\n",
     "import numpy as np\n",
+    "import pandas as pd\n",
     "\n",
     "from highres3dnet import dice_coef, dice_loss, HighRes3DNet"
    ]
@@ -32,8 +36,62 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger = logging.getLogger(name=__name__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_filepath = \"/om/user/jakubk/nobrainer-code/niftynet_to_keras/t1_brainmask.csv\"\n",
+    "df_input = pd.read_csv(input_filepath)\n",
+    "df_input.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_image(filepath):\n",
+    "    \"\"\"Return data and affine given filepath to volume.\"\"\"\n",
+    "    img = nib.load(filepath)\n",
+    "    img.uncache()\n",
+    "    return img.get_fdata(), img.affine\n",
+    "\n",
+    "\n",
+    "def _validate_dims(data):\n",
+    "    \"\"\"Raise `ValueError` if array of data has fewer than 3 dimensions.\"\"\"\n",
+    "    if data.ndim < 3:\n",
+    "        raise ValueError(\"Invalid number of dimensions. Input volume must have\"\n",
+    "                         \" at least 3 dimensions.\")\n",
+    "\n",
+    "\n",
+    "def _reshape(data, newshape):\n",
+    "    \"\"\"Return new array of shape `newshape`.\"\"\"\n",
+    "    logger.info(\"Resizing image to shape {} from shape {}\"\n",
+    "                 .format(data.shape, newshape))\n",
+    "    return data.reshape(newshape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -45,46 +103,47 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "img = nib.load('../data/brainmask.nii.gz')\n",
-    "img_data = img.get_fdata()\n",
+    "row = 0\n",
+    "data_input, data_input_affine = load_image(df_input.loc[row, 't1'])\n",
+    "_validate_dims(data_input)\n",
+    "data_input = _reshape(data_input, volume_input_shape)\n",
     "\n",
-    "if img_data.ndim < 3:\n",
-    "    raise ValueError(\"Invalid number of dimensions. Input volume must have\"\n",
-    "                     \" at least 3 dimensions.\")\n",
-    "\n",
-    "img_data = np.squeeze(img_data)\n",
-    "if img_data.ndim != 3:\n",
-    "    raise ValueError(\"Invalid number of non-single-dimensional entries.\"\n",
-    "                     \" Data must have 3 dimensions after squeezing\"\n",
-    "                     \" single-dimensional entries.\")\n",
-    "\n",
-    "logging.info(\"Resizing image to shape {} from shape {}\"\n",
-    "             .format(img_data.shape, volume_input_shape))\n",
-    "img_data = img_data.reshape(volume_input_shape)"
+    "data_test, data_test_affine = load_image(df_input.loc[row, 'brainmask'])\n",
+    "_validate_dims(data_test)\n",
+    "data_test = _reshape(data_test, volume_input_shape)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "batch_data = np.stack((img_data, img_data, img_data))"
+    "data_input = np.expand_dims(data_input, 0)\n",
+    "data_test = np.expand_dims(data_test, 0)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "model.compile('adam', dice_loss)"
@@ -93,18 +152,74 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model.fit(data_input, data_test, batch_size=1, verbose=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_data = np.stack((img_data, img_data, img_data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [],
    "source": [
     "model.train_on_batch(batch_data, mask_data)"
@@ -113,18 +228,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:tf-cpu]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-tf-cpu-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -136,7 +249,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.5.2"
   },
   "toc": {
    "colors": {

--- a/niftynet_to_keras/highres3dnet.py
+++ b/niftynet_to_keras/highres3dnet.py
@@ -34,6 +34,8 @@ def HighRes3DNet(n_classes, input_tensor=None, input_shape=None):
 
     Parameters
     ----------
+    n_classes : int
+        Number of classes to output in the last convolutional layer.
     input_tensor : optional Keras tensor (i.e., output of `layers.Input()`) to
         use as image input for the model. Does not have to be provided if
         `input_shape` is given.
@@ -42,7 +44,7 @@ def HighRes3DNet(n_classes, input_tensor=None, input_shape=None):
 
     Returns
     -------
-        A Keras model instance.
+    A Keras model instance.
     """
     if input_tensor is not None:
         inputs = input_tensor

--- a/run_singularity.sh
+++ b/run_singularity.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+singularity shell --nv -B /om/user/jakubk:/om/user/jakubk:rw -B /om2:/om2:ro /storage/gablab001/data/singularity-images/nobrainer_2017-12-13.img


### PR DESCRIPTION
Add initial implementation of [HighRes3DNet](https://doi.org/10.1007/978-3-319-59050-9_28).

The network cannot be trained on whole volumes due to memory constraints. A mechanism is included to train on 3-dimensional, non-overlapping blocks of data. The size of the blocks should be tuned to the training goal.

At the moment, the network requires batch sizes that are multiples of the block size. In the near future, update this so that arbitrary batch sizes can be used. Batches can cross volumes. For example, all of the data from one volume might be used, and a subset of blocks from another volume will be included to complete the batch.

If the model is trained on blocks of data, the model will output predicts per block. Not included in this PR is a way to combine the predictions into a complete volume.