### PR TITLE
ENH: fix multi gpu support + generalize utils

### DIFF
--- a/nobrainer/metrics.py
+++ b/nobrainer/metrics.py
@@ -1,5 +1,8 @@
 """Metrics implemented in TensorFlow and NumPy. Functions that end in
 `_numpy` are implemented in NumPy for eager computation.
+
+Functions that have the prefix `streaming_` are meant to be used when
+evaluating TensorFlow estimators with `estimator.eval()`.
 """
 
 import numpy as np

--- a/nobrainer/models/highres3dnet_test.py
+++ b/nobrainer/models/highres3dnet_test.py
@@ -10,7 +10,9 @@ def test_meshnet():
     shape = (1, 10, 10, 10)
     X = np.random.rand(*shape, 1).astype(np.float32)
     y = np.random.randint(0, 9, size=(shape), dtype=np.int32)
-    dset_fn = lambda: tf.data.Dataset.from_tensors((X, y))
+
+    def dset_fn():
+        return tf.data.Dataset.from_tensors((X, y))
 
     estimator = nobrainer.models.HighRes3DNet(
         n_classes=10, optimizer='Adam', learning_rate=0.001)

--- a/nobrainer/models/meshnet_test.py
+++ b/nobrainer/models/meshnet_test.py
@@ -10,7 +10,9 @@ def test_meshnet():
     shape = (1, 10, 10, 10)
     X = np.random.rand(*shape, 1).astype(np.float32)
     y = np.random.randint(0, 9, size=(shape), dtype=np.int32)
-    dset_fn = lambda: tf.data.Dataset.from_tensors((X, y))
+
+    def dset_fn():
+        return tf.data.Dataset.from_tensors((X, y))
 
     estimator = nobrainer.models.MeshNet(
         n_classes=10, optimizer='Adam', n_filters=71, dropout_rate=0.25,

--- a/nobrainer/preprocessing.py
+++ b/nobrainer/preprocessing.py
@@ -4,12 +4,21 @@ import numpy as np
 
 
 def as_blocks(a, block_shape):
-    """Return new array of shape `(n_blocks, *block_shape)`."""
+    """Return new array of shape `(n_blocks, *block_shape)`. This separates `a`
+    into non-overlapping blocks, each with shape `block_shape`.
+    """
+    a = np.asarray(a)
     orig_shape = np.asarray(a.shape)
+
+    if a.ndim != 3:
+        raise ValueError("This function only works for 3D arrays.")
+    if len(block_shape) != 3:
+        raise ValueError("block_shape must have three values.")
+
     blocks = orig_shape // block_shape
     inter_shape = tuple(e for tup in zip(blocks, block_shape) for e in tup)
     new_shape = (-1,) + block_shape
-    perm = (0, 2, 4, 1, 3, 5)  # TODO: generalize this.
+    perm = (0, 2, 4, 1, 3, 5)
     return a.reshape(inter_shape).transpose(perm).reshape(new_shape)
 
 
@@ -22,14 +31,25 @@ def binarize(a, threshold=0, upper=1, lower=0):
 
 
 def from_blocks(a, output_shape):
-    """Initial implementation of function to go from blocks to full volume."""
-    if output_shape != (256, 256, 256) or a.shape != (8, 128, 128, 128):
-        raise ValueError(
-            "This function only accepts arrays of shape (8, 128, 128, 128) and"
-            " output shape of (256, 256, 256). A more general implementation"
-            " is in progress.")
+    """Return new array of shape `output_shape`. This combines non-overlapping
+    blocks, likely created by `as_blocks`."""
+    a = np.asarray(a)
+
+    if a.ndim != 4:
+        raise ValueError("This function only works for 4D arrays.")
+    if len(output_shape) != 3:
+        raise ValueError("output_shape must have three values.")
+
+    n_blocks = a.shape[0]
+    block_shape = a.shape[1:]
+    nn = n_blocks ** (1 / 3)
+    if not nn.is_integer():
+        raise ValueError("Cubed root of number of blocks is not an integer")
+    nn = int(nn)
+    intershape = (nn, nn, nn, *block_shape)
+
     return (
-        a.reshape((2, 2, 2, 128, 128, 128))
+        a.reshape(intershape)
         .transpose((0, 3, 1, 4, 2, 5))
         .reshape(output_shape))
 
@@ -54,6 +74,7 @@ def preprocess_aparcaseg(a, mapping, copy=False):
     """Return preprocessed aparc+aseg array. Replaces values in `a` based on
     diciontary `mapping`, and zeros values that are not values in `mapping`.
     """
+    a = np.asarray(a)
     a = replace(a, mapping=mapping, copy=copy)
     max_label = max(mapping.values())
     a[a > max_label] = 0

--- a/nobrainer/preprocessing.py
+++ b/nobrainer/preprocessing.py
@@ -42,11 +42,11 @@ def from_blocks(a, output_shape):
 
     n_blocks = a.shape[0]
     block_shape = a.shape[1:]
-    nn = n_blocks ** (1 / 3)
-    if not nn.is_integer():
+    ncbrt = np.cbrt(n_blocks)
+    if not ncbrt.is_integer():
         raise ValueError("Cubed root of number of blocks is not an integer")
-    nn = int(nn)
-    intershape = (nn, nn, nn, *block_shape)
+    ncbrt = int(ncbrt)
+    intershape = (ncbrt, ncbrt, ncbrt, *block_shape)
 
     return (
         a.reshape(intershape)

--- a/nobrainer/preprocessing.py
+++ b/nobrainer/preprocessing.py
@@ -42,7 +42,7 @@ def from_blocks(a, output_shape):
 
     n_blocks = a.shape[0]
     block_shape = a.shape[1:]
-    ncbrt = np.cbrt(n_blocks)
+    ncbrt = np.cbrt(n_blocks).round(6)
     if not ncbrt.is_integer():
         raise ValueError("Cubed root of number of blocks is not an integer")
     ncbrt = int(ncbrt)

--- a/nobrainer/preprocessing_test.py
+++ b/nobrainer/preprocessing_test.py
@@ -3,9 +3,12 @@
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from nobrainer.preprocessing import (
-    as_blocks, binarize, from_blocks, normalize_zero_one, preprocess_aparcaseg,
-    replace)
+from nobrainer.preprocessing import as_blocks
+from nobrainer.preprocessing import binarize
+from nobrainer.preprocessing import from_blocks
+from nobrainer.preprocessing import normalize_zero_one
+from nobrainer.preprocessing import preprocess_aparcaseg
+from nobrainer.preprocessing import replace
 
 
 def test_as_blocks():
@@ -13,6 +16,11 @@ def test_as_blocks():
     data = np.ones(shape)
     blocks = as_blocks(data, (10, 10, 10))
     assert blocks.shape == (8, 10, 10, 10)
+
+    data = np.arange(2**3)
+    blocks = as_blocks(data.reshape(2, 2, 2), (1, 1, 1))
+    reference = data[..., None, None, None]
+    assert_array_equal(blocks, reference)
 
     shape = (256, 256, 200)
     data = np.ones(shape)
@@ -43,6 +51,10 @@ def test_from_blocks():
     data = np.ones((256, 256, 256))
     blocks = as_blocks(data, (128, 128, 128))
     assert_array_equal(data, from_blocks(blocks, (256, 256, 256)))
+
+    data = np.arange(12**3).reshape(12, 12, 12)
+    blocks = as_blocks(data, (4, 4, 4))
+    assert_array_equal(data, from_blocks(blocks, (12, 12, 12)))
 
 
 def test_normalize_zero_one():

--- a/predict.py
+++ b/predict.py
@@ -1,63 +1,79 @@
 #!/usr/bin/env python3
+"""Commandline script to predict on T1 volumes."""
 
-import nibabel as nib
+import argparse
+import sys
+
+import nibabel as nb
 import numpy as np
 import tensorflow as tf
 
-import nobrainer
+from nobrainer.models import HighRes3DNet
+from nobrainer.preprocessing import as_blocks
+from nobrainer.preprocessing import from_blocks
+from nobrainer.preprocessing import normalize_zero_one
 
 
-def from_blocks(a, output_shape):
-    """Initial implementation of function to go from blocks to full volume."""
-    return (
-        a.reshape((2, 2, 2, 128, 128, 128))
-        .transpose((0, 3, 1, 4, 2, 5))
-        .reshape(output_shape))
+def predict(features_filepath, batch_size, block_shape):
+    """Run `model_obj.predict` on features data in `features_filepath`."""
+    x_img = nb.load(features_filepath)
 
+    x = np.asarray(x_img.dataobj).astype(np.float32)
+    x = as_blocks(x, block_shape)
+    x = normalize_zero_one(x)
+    x = x[..., np.newaxis]
 
-def predict(filepath):
-    """Return Nibabel Nifti image of predicted brainmask for neuroimaging file
-    `filepath`.
-    """
-    x, x_affine = nobrainer.io.load_volume(
-        filepath, dtype='float32', return_affine=True
-    )
+    input_fn = tf.estimator.inputs.numpy_input_fn(
+        x=x, shuffle=False, batch_size=batch_size)
 
-    assert x.shape == (256, 256, 256), "shape must be (256, 256, 256)."
+    # Load model.
+    # TODO(kaczmarj): use tensorflow serving or the export api instead of this.
+    # also these shouldn't be hardcoded.
+    model = HighRes3DNet(
+        n_classes=2,
+        model_dir="/opt/nobrainer/trained-models/highres3dnet-brainmask")
 
-    x = nobrainer.preprocessing.as_blocks(x, (128, 128, 128))
-    x = np.expand_dims(x, -1)
-    x = nobrainer.preprocessing.normalize_zero_one(x)
-
-    inputs = tf.estimator.inputs.numpy_input_fn(
-        x=x, shuffle=False, batch_size=4
-    )
-
-    model = nobrainer.models.MeshNet(
-        2, model_dir='models-hdf5/meshnet_20180219-220005'
-    )
-
-    generator = model.predict(input_fn=inputs)
-    predictions = np.zeros((8, 128, 128, 128))
-
+    generator = model.predict(input_fn=input_fn)
+    predictions = np.zeros(x.shape[:-1])
     for ii, block in enumerate(generator):
-        predictions[ii, Ellipsis] = block
+        predictions[ii, Ellipsis] = block['class_ids']
+    predictions = from_blocks(predictions, x_img.shape)
 
-    predictions = from_blocks(predictions, (256, 256, 256))
+    return nb.Nifti1Image(
+        predictions, affine=x_img.affine, header=x_img.header)
 
-    return nib.Nifti1Image(predictions, x_affine)
+
+def create_parser():
+    """Return argument parser."""
+    p = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    p.add_argument('input', help="path to T1 on which to predict")
+    p.add_argument('output', help="path to save predictions")
+    p.add_argument(
+        '--batch-size', type=int, default=4,
+        help="Batch size. Use lower value if resources are limited")
+    p.add_argument(
+        '--block-shape', nargs=3, type=int, default=[128, 128, 128],
+        help="Separate input volume into 3D blocks of this shape before"
+             " training")
+    return p
+
+
+def parse_args(args):
+    """Return namespace of arguments."""
+    parser = create_parser()
+    return parser.parse_args(args)
 
 
 if __name__ == '__main__':
-    import sys
+    namespace = parse_args(sys.argv[1:])
+    params = vars(namespace)
 
-    if len(sys.argv) < 3:
-        raise ValueError("input and output filepaths must be specified.")
+    params['block_shape'] = tuple(params['block_shape'])
 
-    input_filepath = sys.argv[1]
-    output_filepath = sys.argv[2]
+    predicted_img = predict(
+        params['input'],
+        batch_size=params['batch_size'],
+        block_shape=params['block_shape'])
 
-    brainmask_nifti = predict(input_filepath)
-
-    brainmask_nifti.to_filename(output_filepath)
-
+    nb.save(predicted_img, params['output'])

--- a/vols2hdf5_test.py
+++ b/vols2hdf5_test.py
@@ -7,7 +7,7 @@ import tempfile
 import h5py
 import nibabel as nb
 import numpy as np
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 import pandas as pd
 
 from nobrainer.preprocessing import as_blocks
@@ -193,5 +193,5 @@ def test_vols2hdf5_three():
             tuple(as_blocks(labels[i], block_shape=(16, 16, 16))
                   for i in range(labels.shape[0])))
 
-        assert_array_equal(features_16, features_blocked)
-        assert_array_equal(labels_16, labels_blocked)
+        assert_allclose(features_16, features_blocked)
+        assert_allclose(labels_16, labels_blocked)


### PR DESCRIPTION
This PR 

- fixes multi-gpu support after adding periodic evaluation
- uses `tf.estimator.train_and_evaluate` to add periodic evaluation
- generalizes `nobrainer.preprocessing.from_blocks` to accept arbitrary shapes