### PR TITLE
ENH: finish `replace` method and write tests for nobrainer.volume

### DIFF
--- a/nobrainer/__init__.py
+++ b/nobrainer/__init__.py
@@ -4,6 +4,7 @@ import tensorflow as tf
 
 # For tensorflow<2.0
 # tf.enable_eager_execution()
+tf.enable_v2_tensorshape()
 
 if LooseVersion(tf.__version__) < LooseVersion("1.13.1"):
     raise ValueError(

--- a/nobrainer/tests/losses_test.py
+++ b/nobrainer/tests/losses_test.py
@@ -40,9 +40,9 @@ def test_dice():
     dices = np.empty(x.shape[0])
     for i in range(x.shape[0]):
         dices[i] = scipy.spatial.distance.dice(x[i].flatten(), y[i].flatten())
-    assert_allclose(losses.dice(x, y, axis=(1, 2, 3, 4)), dices)
-    assert_allclose(losses.Dice(axis=(1, 2, 3, 4))(x, y), dices.mean())
-    assert_allclose(losses.Dice(axis=(1, 2, 3, 4))(y, x), dices.mean())
+    assert_allclose(losses.dice(x, y, axis=(1, 2, 3, 4)), dices, rtol=1e-05)
+    assert_allclose(losses.Dice(axis=(1, 2, 3, 4))(x, y), dices.mean(), rtol=1e-05)
+    assert_allclose(losses.Dice(axis=(1, 2, 3, 4))(y, x), dices.mean(), rtol=1e-05)
 
 
 def test_generalized_dice():

--- a/nobrainer/tests/losses_test.py
+++ b/nobrainer/tests/losses_test.py
@@ -1,4 +1,6 @@
 import numpy as np
+from numpy.testing import assert_allclose
+from numpy.testing import assert_array_equal
 import pytest
 import scipy.spatial.distance
 import tensorflow as tf
@@ -10,25 +12,25 @@ def test_dice():
     x = np.zeros(4)
     y = np.zeros(4)
     out = losses.dice(x, y, axis=None).numpy()
-    assert np.allclose(out, 0)
+    assert_allclose(out, 0)
 
     x = np.ones(4)
     y = np.ones(4)
     out = losses.dice(x, y, axis=None).numpy()
-    assert np.allclose(out, 0)
+    assert_allclose(out, 0)
 
     x = [0., 0., 1., 1.]
     y = [1., 1., 1., 1.]
     out = losses.dice(x, y, axis=None).numpy()
     ref = scipy.spatial.distance.dice(x, y)
-    assert np.allclose(out, ref)
+    assert_allclose(out, ref)
 
     x = [0., 0., 1., 1.]
     y = [1., 1., 0., 0.]
     out = losses.dice(x, y, axis=None).numpy()
     ref = scipy.spatial.distance.dice(x, y)
-    assert np.allclose(out, ref)
-    assert np.allclose(out, 1)
+    assert_allclose(out, ref)
+    assert_allclose(out, 1)
 
     x = np.ones((4, 32, 32, 32, 1), dtype=np.float32)
     y = x.copy()
@@ -38,29 +40,29 @@ def test_dice():
     dices = np.empty(x.shape[0])
     for i in range(x.shape[0]):
         dices[i] = scipy.spatial.distance.dice(x[i].flatten(), y[i].flatten())
-    assert np.allclose(losses.dice(x, y, axis=(1, 2, 3, 4)), dices)
-    assert np.allclose(losses.Dice(axis=(1, 2, 3, 4))(x, y), dices.mean())
-    assert np.allclose(losses.Dice(axis=(1, 2, 3, 4))(y, x), dices.mean())
+    assert_allclose(losses.dice(x, y, axis=(1, 2, 3, 4)), dices)
+    assert_allclose(losses.Dice(axis=(1, 2, 3, 4))(x, y), dices.mean())
+    assert_allclose(losses.Dice(axis=(1, 2, 3, 4))(y, x), dices.mean())
 
 
 def test_generalized_dice():
     shape = (8, 32, 32, 32, 16)
     x = np.zeros(shape)
     y = np.zeros(shape)
-    assert np.array_equal(losses.generalized_dice(x, y), np.zeros(shape[0]))
+    assert_array_equal(losses.generalized_dice(x, y), np.zeros(shape[0]))
 
     shape = (8, 32, 32, 32, 16)
     x = np.ones(shape)
     y = np.ones(shape)
-    assert np.array_equal(losses.generalized_dice(x, y), np.zeros(shape[0]))
+    assert_array_equal(losses.generalized_dice(x, y), np.zeros(shape[0]))
 
     shape = (8, 32, 32, 32, 16)
     x = np.ones(shape)
     y = np.zeros(shape)
     # Why aren't the losses exactly one? Could it be the propogation of floating
     # point inaccuracies when summing?
-    assert np.allclose(losses.generalized_dice(x, y), np.ones(shape[0]), atol=1e-03)
-    assert np.allclose(losses.GeneralizedDice(axis=(1, 2, 3))(x, y), losses.generalized_dice(x, y))
+    assert_allclose(losses.generalized_dice(x, y), np.ones(shape[0]), atol=1e-03)
+    assert_allclose(losses.GeneralizedDice(axis=(1, 2, 3))(x, y), losses.generalized_dice(x, y))
 
     x = np.ones((4, 32, 32, 32, 1), dtype=np.float64)
     y = x.copy()
@@ -71,32 +73,32 @@ def test_generalized_dice():
     # makes the generalized form slightly different from Dice.
     gd = losses.generalized_dice(x, y, axis=(1, 2, 3)).numpy()
     dd = losses.dice(x, y, axis=(1, 2, 3, 4)).numpy()
-    assert np.allclose(gd, dd, rtol=1e-02)  # is this close enough?
+    assert_allclose(gd, dd, rtol=1e-02)  # is this close enough?
 
 
 def test_jaccard():
     x = np.zeros(4)
     y = np.zeros(4)
     out = losses.jaccard(x, y, axis=None).numpy()
-    assert np.allclose(out, 0)
+    assert_allclose(out, 0)
 
     x = np.ones(4)
     y = np.ones(4)
     out = losses.jaccard(x, y, axis=None).numpy()
-    assert np.allclose(out, 0)
+    assert_allclose(out, 0)
 
     x = [0., 0., 1., 1.]
     y = [1., 1., 1., 1.]
     out = losses.jaccard(x, y, axis=None).numpy()
     ref = scipy.spatial.distance.jaccard(x, y)
-    assert np.allclose(out, ref)
+    assert_allclose(out, ref)
 
     x = [0., 0., 1., 1.]
     y = [1., 1., 0., 0.]
     out = losses.jaccard(x, y, axis=None).numpy()
     ref = scipy.spatial.distance.jaccard(x, y)
-    assert np.allclose(out, ref)
-    assert np.allclose(out, 1)
+    assert_allclose(out, ref)
+    assert_allclose(out, 1)
 
     x = np.ones((4, 32, 32, 32, 1), dtype=np.float32)
     y = x.copy()
@@ -106,9 +108,9 @@ def test_jaccard():
     jaccards = np.empty(x.shape[0])
     for i in range(x.shape[0]):
         jaccards[i] = scipy.spatial.distance.jaccard(x[i].flatten(), y[i].flatten())
-    assert np.allclose(losses.jaccard(x, y, axis=(1, 2, 3, 4)), jaccards)
-    assert np.allclose(losses.Jaccard(axis=(1, 2, 3, 4))(x, y), jaccards.mean())
-    assert np.allclose(losses.Jaccard(axis=(1, 2, 3, 4))(y, x), jaccards.mean())
+    assert_allclose(losses.jaccard(x, y, axis=(1, 2, 3, 4)), jaccards)
+    assert_allclose(losses.Jaccard(axis=(1, 2, 3, 4))(x, y), jaccards.mean())
+    assert_allclose(losses.Jaccard(axis=(1, 2, 3, 4))(y, x), jaccards.mean())
 
 
 @pytest.mark.xfail

--- a/nobrainer/tests/metrics_test.py
+++ b/nobrainer/tests/metrics_test.py
@@ -1,4 +1,6 @@
 import numpy as np
+from numpy.testing import assert_allclose
+from numpy.testing import assert_array_equal
 import pytest
 import scipy.spatial.distance
 import tensorflow as tf
@@ -13,27 +15,27 @@ def test_dice():
     x = np.zeros(4)
     y = np.zeros(4)
     out = metrics.dice(x, y, axis=None).numpy()
-    assert np.allclose(out, 1)
+    assert_allclose(out, 1)
 
     x = np.ones(4)
     y = np.ones(4)
     out = metrics.dice(x, y, axis=None).numpy()
-    assert np.allclose(out, 1)
+    assert_allclose(out, 1)
 
     x = [0., 0., 1., 1.]
     y = [1., 1., 1., 1.]
     out = metrics.dice(x, y, axis=None).numpy()
     ref = 1. - scipy.spatial.distance.dice(x, y)
-    assert np.allclose(out, ref)
+    assert_allclose(out, ref)
     jac_out = metrics.jaccard(x, y, axis=None).numpy()
-    assert np.allclose(out, 2. * jac_out / (1. + jac_out))
+    assert_allclose(out, 2. * jac_out / (1. + jac_out))
 
     x = [0., 0., 1., 1.]
     y = [1., 1., 0., 0.]
     out = metrics.dice(x, y, axis=None).numpy()
     ref = 1. - scipy.spatial.distance.dice(x, y)
-    assert np.allclose(out, ref, atol=1e-07)
-    assert np.allclose(out, 0, atol=1e-07)
+    assert_allclose(out, ref, atol=1e-07)
+    assert_allclose(out, 0, atol=1e-07)
 
     x = np.ones((4, 32, 32, 32, 1), dtype=np.float32)
     y = x.copy()
@@ -43,26 +45,26 @@ def test_dice():
     dices = np.empty(x.shape[0])
     for i in range(x.shape[0]):
         dices[i] = 1. - scipy.spatial.distance.dice(x[i].flatten(), y[i].flatten())
-    assert np.allclose(metrics.dice(x, y, axis=(1, 2, 3, 4)), dices)
+    assert_allclose(metrics.dice(x, y, axis=(1, 2, 3, 4)), dices)
 
 
 def test_generalized_dice():
     shape = (8, 32, 32, 32, 16)
     x = np.zeros(shape)
     y = np.zeros(shape)
-    assert np.array_equal(metrics.generalized_dice(x, y), np.ones(shape[0]))
+    assert_array_equal(metrics.generalized_dice(x, y), np.ones(shape[0]))
 
     shape = (8, 32, 32, 32, 16)
     x = np.ones(shape)
     y = np.ones(shape)
-    assert np.array_equal(metrics.generalized_dice(x, y), np.ones(shape[0]))
+    assert_array_equal(metrics.generalized_dice(x, y), np.ones(shape[0]))
 
     shape = (8, 32, 32, 32, 16)
     x = np.ones(shape)
     y = np.zeros(shape)
     # Why aren't the scores exactly zero? Could it be the propogation of floating
     # point inaccuracies when summing?
-    assert np.allclose(metrics.generalized_dice(x, y), np.zeros(shape[0]), atol=1e-03)
+    assert_allclose(metrics.generalized_dice(x, y), np.zeros(shape[0]), atol=1e-03)
 
     x = np.ones((4, 32, 32, 32, 1), dtype=np.float64)
     y = x.copy()
@@ -73,34 +75,34 @@ def test_generalized_dice():
     # makes the generalized form slightly different from Dice.
     gd = metrics.generalized_dice(x, y, axis=(1, 2, 3)).numpy()
     dd = metrics.dice(x, y, axis=(1, 2, 3, 4)).numpy()
-    assert np.allclose(gd, dd, rtol=1e-02)  # is this close enough?
+    assert_allclose(gd, dd, rtol=1e-02)  # is this close enough?
 
 
 def test_jaccard():
     x = np.zeros(4)
     y = np.zeros(4)
     out = metrics.jaccard(x, y, axis=None).numpy()
-    assert np.allclose(out, 1)
+    assert_allclose(out, 1)
 
     x = np.ones(4)
     y = np.ones(4)
     out = metrics.jaccard(x, y, axis=None).numpy()
-    assert np.allclose(out, 1)
+    assert_allclose(out, 1)
 
     x = [0., 0., 1., 1.]
     y = [1., 1., 1., 1.]
     out = metrics.jaccard(x, y, axis=None).numpy()
     ref = 1. - scipy.spatial.distance.jaccard(x, y)
-    assert np.allclose(out, ref)
+    assert_allclose(out, ref)
     dice_out = metrics.dice(x, y, axis=None).numpy()
-    assert np.allclose(out, dice_out / (2. - dice_out))
+    assert_allclose(out, dice_out / (2. - dice_out))
 
     x = [0., 0., 1., 1.]
     y = [1., 1., 0., 0.]
     out = metrics.jaccard(x, y, axis=None).numpy()
     ref = 1. - scipy.spatial.distance.jaccard(x, y)
-    assert np.allclose(out, ref, atol=1e-07)
-    assert np.allclose(out, 0, atol=1e-07)
+    assert_allclose(out, ref, atol=1e-07)
+    assert_allclose(out, 0, atol=1e-07)
 
     x = np.ones((4, 32, 32, 32, 1), dtype=np.float32)
     y = x.copy()
@@ -110,7 +112,7 @@ def test_jaccard():
     jaccards = np.empty(x.shape[0])
     for i in range(x.shape[0]):
         jaccards[i] = 1. - scipy.spatial.distance.jaccard(x[i].flatten(), y[i].flatten())
-    assert np.allclose(metrics.jaccard(x, y, axis=(1, 2, 3, 4)), jaccards)
+    assert_allclose(metrics.jaccard(x, y, axis=(1, 2, 3, 4)), jaccards)
 
 
 def test_tversky():
@@ -121,12 +123,12 @@ def test_tversky():
     # Test that tversky and dice are same when alpha = beta = 0.5
     dice = metrics.dice(y_true, y_pred).numpy()
     tversky = metrics.tversky(y_true, y_pred, axis=(1, 2, 3), alpha=0.5, beta=0.5).numpy()
-    assert np.allclose(dice, tversky)
+    assert_allclose(dice, tversky)
 
     # Test that tversky and jaccard are same when alpha = beta = 1.0
     jaccard = metrics.jaccard(y_true, y_pred).numpy()
     tversky = metrics.tversky(y_true, y_pred, axis=(1, 2, 3), alpha=1., beta=1.).numpy()
-    assert np.allclose(jaccard, tversky)
+    assert_allclose(jaccard, tversky)
 
     with pytest.raises(ValueError):
         metrics.tversky([0., 0., 1.], [1., 0., 1.], axis=0)

--- a/nobrainer/tests/volume_test.py
+++ b/nobrainer/tests/volume_test.py
@@ -1,0 +1,136 @@
+import numpy as np
+from numpy.testing import assert_array_equal
+import pytest
+import tensorflow as tf
+
+from nobrainer import volume
+
+
+@pytest.mark.xfail
+def test_get_dataset():
+    assert False
+
+
+@pytest.mark.xfail
+def test_apply_random_transform():
+    assert False
+
+
+@pytest.mark.xfail
+def test_apply_random_transform_dataset():
+    assert False
+
+
+def test_binarize():
+    x = [ 0.49671415, -0.1382643 ,  0.64768854,  1.52302986, -0.23415337,
+       -0.23413696,  1.57921282,  0.76743473]
+    x = np.asarray(x, dtype='float64')
+    expected = np.array([ True, False,  True,  True, False, False,  True,  True])
+    result = volume.binarize(x)
+    assert_array_equal(expected, result)
+    assert result.dtype == tf.float64
+    result = volume.binarize(x.astype(np.float32))
+    assert_array_equal(expected, result)
+    assert result.dtype == tf.float32
+
+    x = np.asarray([-2,  0,  2,  0,  2, -2, -1,  1], dtype=np.int32)
+    expected = np.array([False, False, True, False, True, False, False, True])
+    result = volume.binarize(x)
+    assert_array_equal(expected, result)
+    assert result.dtype == tf.int32
+    result = volume.binarize(x.astype(np.int64))
+    assert_array_equal(expected, result)
+    assert result.dtype == tf.int64
+
+
+def test_replace():
+    data = np.arange(5)
+    mapping = {
+        0: 10,
+        1: 20,
+        2: 30,
+        3: 40,
+        4: 30,
+    }
+    output = volume.replace(data, mapping)
+    assert_array_equal(output, [10, 20, 30, 40, 30])
+
+    # Test that overlapping keys and values gives correct result.
+    data = np.arange(5)
+    mapping = {
+        0: 1,
+        1: 2,
+        2: 3,
+        3: 4,
+    }
+    output = volume.replace(data, mapping)
+    assert_array_equal(output, [1, 2, 3, 4, 4])
+
+    data = np.arange(8).reshape(2, 2, 2)
+    mapping = {0: 100, 100: 10, 10: 5, 3: 5}
+    outputs = volume.replace(data, mapping, zero=False)
+    expected = data.copy()
+    expected[0, 0, 0] = 100
+    expected[0, 1, 1] = 5
+    assert_array_equal(outputs, expected)
+
+    # Zero values not in mapping values.
+    outputs = volume.replace(data, mapping, zero=True)
+    expected = np.zeros_like(data)
+    expected[0, 0, 0] = 100
+    expected[0, 1, 1] = 5
+    expected[1, 0, 1] = 5
+    assert_array_equal(outputs, expected)
+
+
+def test_standardize():
+    x = np.random.randn(10, 10, 10).astype(np.float32)
+    outputs = volume.standardize(x).numpy()
+    assert np.allclose(outputs.mean(), 0, atol=1e-07)
+    assert np.allclose(outputs.std(), 1, atol=1e-07)
+
+
+def test_to_blocks():
+    x = np.arange(8).reshape(2, 2, 2)
+    outputs = volume.to_blocks(x, (1, 1, 1)).numpy()
+    expected = np.array([[[[0]]],
+                       [[[1]]],
+                       [[[2]]],
+                       [[[3]]],
+                       [[[4]]],
+                       [[[5]]],
+                       [[[6]]],
+                       [[[7]]]])
+    assert_array_equal(outputs, expected)
+    outputs = volume.to_blocks(x, (2, 2, 2)).numpy()
+    assert_array_equal(outputs, x[None])
+
+    with pytest.raises(tf.errors.InvalidArgumentError):
+        volume.to_blocks(x, (3, 3, 3))
+
+
+def test_from_blocks():
+    x = np.arange(64).reshape(4, 4, 4)
+    block_shape = (2, 2, 2)
+    outputs = volume.from_blocks(volume.to_blocks(x, block_shape), x.shape)
+    assert_array_equal(outputs, x)
+
+
+@pytest.mark.xfail
+def test_get_preprocess_fn():
+    assert False
+
+
+@pytest.mark.xfail
+def test_preprocess_binary():
+    assert False
+
+
+@pytest.mark.xfail
+def test_preprocess_multiclass():
+    assert False
+
+
+@pytest.mark.xfail
+def test_get_steps_per_epoch():
+    assert False

--- a/nobrainer/tests/volume_test.py
+++ b/nobrainer/tests/volume_test.py
@@ -11,14 +11,37 @@ def test_get_dataset():
     assert False
 
 
-@pytest.mark.xfail
 def test_apply_random_transform():
-    assert False
+    shape = (10, 10, 10)
+    x = np.ones(shape).astype(np.float32)
+    y = np.random.randint(0, 2, size=shape).astype(np.float32)
+    x, y = volume.apply_random_transform(x, y)
+    x = x.numpy()
+    y = y.numpy()
 
+    # Test that values were not changed in the labels.
+    assert_array_equal(np.unique(y), [0, 1])
+    assert x.shape == shape
+    assert y.shape == shape
 
-@pytest.mark.xfail
-def test_apply_random_transform_dataset():
-    assert False
+    with pytest.raises(ValueError):
+        x, y = volume.apply_random_transform(
+            np.ones((10, 10, 10)), np.ones((10, 10, 12)))
+    with pytest.raises(ValueError):
+        x, y = volume.apply_random_transform(
+            np.ones((10, 10)), np.ones((10, 10)))
+
+    shape = (10, 10, 10)
+    x = np.random.randn(*shape).astype(np.float32)
+    y = np.random.randint(0, 2, size=shape).astype(np.float32)
+    x0, y0 = volume.apply_random_transform(x, y)
+    x1, y1 = volume.apply_random_transform(x, y)
+    assert not np.array_equal(x, x0)
+    assert not np.array_equal(x, x1)
+    assert not np.array_equal(y, y0)
+    assert not np.array_equal(y, y1)
+    assert not np.array_equal(x0, x1)
+    assert not np.array_equal(y0, y1)
 
 
 def test_binarize():
@@ -131,6 +154,20 @@ def test_preprocess_multiclass():
     assert False
 
 
-@pytest.mark.xfail
 def test_get_steps_per_epoch():
-    assert False
+    nsteps = volume.get_steps_per_epoch(
+        n_volumes=1, volume_shape=(256, 256, 256), block_shape=(64, 64, 64),
+        batch_size=1)
+    assert nsteps == 64
+    nsteps = volume.get_steps_per_epoch(
+        n_volumes=1, volume_shape=(256, 256, 256), block_shape=(64, 64, 64),
+        batch_size=64)
+    assert nsteps == 1
+    nsteps = volume.get_steps_per_epoch(
+        n_volumes=1, volume_shape=(256, 256, 256), block_shape=(64, 64, 64),
+        batch_size=63)
+    assert nsteps == 2
+    nsteps = volume.get_steps_per_epoch(
+        n_volumes=10, volume_shape=(256, 256, 256), block_shape=(128, 128, 128),
+        batch_size=4)
+    assert nsteps == 20

--- a/nobrainer/transform.py
+++ b/nobrainer/transform.py
@@ -92,11 +92,11 @@ def get_affine(volume_shape, rotation=[0, 0, 0], translation=[0, 0, 0]):
     volume_shape = tf.cast(volume_shape, tf.float32)
     rotation = tf.cast(rotation, tf.float32)
     translation = tf.cast(translation, tf.float32)
-    if volume_shape.shape[0].value != 3:
+    if volume_shape.shape[0] != 3:
         raise ValueError("`volume_shape` must have three values")
-    if rotation.shape[0].value != 3:
+    if rotation.shape[0] != 3:
         raise ValueError("`rotation` must have three values")
-    if translation.shape[0].value != 3:
+    if translation.shape[0] != 3:
         raise ValueError("`translation` must have three values")
 
     # ROTATION
@@ -181,8 +181,7 @@ def _get_coordinates(volume_shape):
     if len(volume_shape) != 3:
         raise ValueError("shape must have 3 items.")
     dtype = tf.float32
-    # rows, cols, depth = np.array(volume_shape)
-    rows, cols, depth = [s.value for s in volume_shape]
+    rows, cols, depth = volume_shape
 
     out = tf.meshgrid(
         tf.range(rows, dtype=dtype),
@@ -281,7 +280,12 @@ def _get_voxels(volume, coords):
     x = tf.cast(volume, tf.float32)
     coords = tf.cast(coords, tf.float32)
 
-    rows, cols, depth = [s.value for s in x.shape]
+    if len(x.shape) != 3:
+        raise ValueError("`volume` must be rank 3")
+    if len(coords.shape) != 2 or coords.shape[1] != 3:
+        raise ValueError("`coords` must have shape `(N, 3)`.")
+
+    rows, cols, depth = x.shape
 
     # Points in flattened array representation.
     fcoords = coords[:, 0] * cols * depth + coords[:, 1] * depth + coords[:, 2]

--- a/nobrainer/volume.py
+++ b/nobrainer/volume.py
@@ -120,46 +120,23 @@ def apply_random_transform(features, labels):
     interpolated trilinearly, and labels are interpolated with nearest
     neighbors.
     """
+    if len(features.shape) != 3 or len(labels.shape) != 3:
+        raise ValueError("features and labels must be rank 3")
+    if features.shape != labels.shape:
+        raise ValueError("shape of features and labels must be the same.")
     # Rotate -180 degrees to 180 degrees in three dimensions.
     rotation = tf.random.uniform(
         shape=[3], minval=-np.pi, maxval=np.pi, dtype=tf.float32)
 
     # Translate at most 5% in any direction, so there's less chance of
     # important data going out of view.
-    maxval = 0.05 * features.shape[0].value
+    maxval = 0.05 * features.shape[0]
     translation = tf.random.uniform(
         shape=[3], minval=-maxval, maxval=maxval, dtype=tf.float32)
 
-    volume_shape = np.asarray([s.value for s in features.shape])
+    volume_shape = np.asarray(features.shape)
     matrix = get_affine(volume_shape=volume_shape, rotation=rotation, translation=translation)
     return warp_features_labels(features=features, labels=labels, matrix=matrix)
-
-
-def apply_random_transform_dataset(features, labels):
-    """Apply a random rigid transformation to `features` and `labels`.
-
-    The same transformation is applied to features and labels. Features are
-    interpolated trilinearly, and labels are interpolated with nearest
-    neighbors.
-
-    Returns
-    -------
-    `tf.data.Dataset` of randomly transformed features and labels.
-    """
-    # Rotate -180 degrees to 180 degrees in three dimensions.
-    rotation = tf.random.uniform(
-        shape=[3], minval=-np.pi, maxval=np.pi, dtype=tf.float32)
-
-    # Translate at most 5% in any direction, so there's less chance of
-    # important data going out of view.
-    maxval = 0.05 * features.shape[0].value
-    translation = tf.random.uniform(
-        shape=[3], minval=-maxval, maxval=maxval, dtype=tf.float32)
-
-    volume_shape = np.asarray([s.value for s in features.shape])
-    matrix = get_affine(volume_shape=volume_shape, rotation=rotation, translation=translation)
-    x, y = warp_features_labels(features=features, labels=labels, matrix=matrix)
-    return tf.data.Dataset.from_tensor_slices((x, y))
 
 
 def binarize(x):


### PR DESCRIPTION
`nobrainer.volume.replace` can now be used for multi-class segmentation. the function is implemented in pure tensorflow, so it can be XLA compiled and serialized in a graph.

this PR also removes the function `nobrainer.volume.apply_random_transform_dataset` — turns out it was never used...